### PR TITLE
read処理の単体テスト実装

### DIFF
--- a/src/main/java/com/information/user/User.java
+++ b/src/main/java/com/information/user/User.java
@@ -1,5 +1,7 @@
 package com.information.user;
 
+import java.util.Objects;
+
 public class User {
     private Integer id;
     private String name;
@@ -30,5 +32,19 @@ public class User {
 
     public String getBirthdate() {
         return birthdate;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof User user)) return false;
+        return Objects.equals(id, user.id) &&
+                Objects.equals(name, user.name) &&
+                Objects.equals(birthdate, user.birthdate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, birthdate);
     }
 }

--- a/src/test/java/com/information/user/service/UserServiceTest.java
+++ b/src/test/java/com/information/user/service/UserServiceTest.java
@@ -1,0 +1,55 @@
+package com.information.user.service;
+
+import com.information.user.User;
+import com.information.user.UserMapper;
+import com.information.user.UserNotFoundException;
+import com.information.user.UserService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @InjectMocks
+    UserService userService;
+
+    @Mock
+    UserMapper userMapper;
+
+    @Test
+    void 全てのユーザーが取得できること() {
+        List<User> users = List.of(
+                new User(1, "suzuki", "1973/07/22"),
+                new User(2, "kato", "1960/03/15"),
+                new User(3, "tanaka", "1991/12/08")
+        );
+        doReturn(users).when(userMapper).getAll();
+        List<User> actual = userService.findAll();
+        assertThat(actual).isEqualTo(users);
+        verify(userMapper).getAll();
+    }
+
+    @Test
+    void 存在するユーザーのIDを指定したときに正常にユーザーを取得できること() {
+        doReturn(Optional.of(new User(1, "suzuki", "1973/07/22"))).when(userMapper).findById(1);
+        User actual = userService.findById(1);
+        assertThat(actual).isEqualTo(new User(1, "suzuki", "1973/07/22"));
+    }
+
+    @Test
+    void 存在しないユーザーのIDを指定したときに例外を返すこと() {
+        doReturn(Optional.empty()).when(userMapper).findById(0);
+        assertThrows(UserNotFoundException.class, () -> userService.findById(0));
+    }
+}


### PR DESCRIPTION
# 目的
read処理のServiceクラスに対する単体テストを実装すること。

# 今回テストしたい内容
- 全てのユーザーが取得できること
- 存在するユーザーのIDを指定したときに正常にユーザーを取得できること
- 存在しないユーザーのIDを指定したときに例外を返すこと

# テスト実行結果
![image](https://github.com/kino41/RaiseTech_last/assets/155221768/29455ae0-57b7-4c96-abb1-106d07c7ba34)

- 実行結果に Tests passed:3 とあり、3つのテストが正常に行われたことを確認。