### PR TITLE
post,delete処理の単体テスト実装

### DIFF
--- a/src/main/java/com/information/user/UserService.java
+++ b/src/main/java/com/information/user/UserService.java
@@ -50,6 +50,9 @@ public class UserService {
     }
 
     public void delete(Integer id) {
+        if (!userMapper.findById(id).isPresent()) {
+            throw new UserNotFoundException("user not found");
+        }
         int affectedRows = userMapper.deleteById(id);
         if (affectedRows <= 0) {
             throw new UserNotFoundException("user not found");

--- a/src/test/java/com/information/user/service/UserServiceTest.java
+++ b/src/test/java/com/information/user/service/UserServiceTest.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -69,5 +70,13 @@ class UserServiceTest {
         doReturn(1).when(userMapper).deleteById(1);
         userService.delete(1);
         verify(userMapper).deleteById(1);
+    }
+
+    @Test
+    void 存在しないユーザーのIDを指定したときに削除が行われず例外を返すこと() {
+        doReturn(Optional.empty()).when(userMapper).findById(0);
+        assertThrows(UserNotFoundException.class, () -> userService.delete(0));
+        verify(userMapper, never()).deleteById(0);
+        verify(userMapper).findById(0);
     }
 }

--- a/src/test/java/com/information/user/service/UserServiceTest.java
+++ b/src/test/java/com/information/user/service/UserServiceTest.java
@@ -45,11 +45,29 @@ class UserServiceTest {
         doReturn(Optional.of(new User(1, "suzuki", "1973/07/22"))).when(userMapper).findById(1);
         User actual = userService.findById(1);
         assertThat(actual).isEqualTo(new User(1, "suzuki", "1973/07/22"));
+        verify(userMapper).findById(1);
     }
 
     @Test
     void 存在しないユーザーのIDを指定したときに例外を返すこと() {
         doReturn(Optional.empty()).when(userMapper).findById(0);
         assertThrows(UserNotFoundException.class, () -> userService.findById(0));
+    }
+
+    @Test
+    void 新規のユーザーをIDと紐付けて正常に登録できること() {
+        User newUser = new User(4, "hayashi", "1992/03/09");
+        userService.insert(newUser);
+        verify(userMapper).insert(newUser);
+    }
+
+    @Test
+    void 存在するユーザーのIDを指定したときに正常にユーザーを削除できること() {
+        doReturn(Optional.of(new User(1, "suzuki", "1973/07/22"))).when(userMapper).findById(1);
+        User actual = userService.findById(1);
+        assertThat(actual).isEqualTo(new User(1, "suzuki", "1973/07/22"));
+        doReturn(1).when(userMapper).deleteById(1);
+        userService.delete(1);
+        verify(userMapper).deleteById(1);
     }
 }


### PR DESCRIPTION
# 目的
post 、 delete 処理の Service クラスに対する単体テストを実装します。
( patch 処理は後ほど実装予定です。)

# テスト実行結果
![image](https://github.com/kino41/RaiseTech_last/assets/155221768/87cdd525-9f7c-4dca-aa4b-d598622691e3)
- エラーが発生していないことを確認
- 現時点で5つのテストを作成していることを確認

![image](https://github.com/kino41/RaiseTech_last/assets/155221768/0d6afe75-d24b-4a03-8f58-30d03ea33cfd)
- 今回追加した2つのテストコード横にチェックマークが入っており正常にテストが通ったことを確認