### PR TITLE
read処理のデータベーステストと結合テストの実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
+	testImplementation 'com.github.database-rider:rider-spring:1.42.0'
 }
 
 tasks.named('test') {

--- a/src/test/java/com/information/user/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/com/information/user/integrationtest/UserRestApiIntegrationTest.java
@@ -71,7 +71,7 @@ class UserRestApiIntegrationTest {
     @Test
     @DataSet(value = "datasets/users.yml")
     @Transactional
-    void 存在しないユーザーのIDを指定したときにエラー内容を含めた例外を返すこと() throws Exception {
+    void 存在しないユーザーのIDを指定したときに404エラーを返すこと() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/users/0"))
                 .andExpect(status().isNotFound())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.timestamp").exists())

--- a/src/test/java/com/information/user/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/com/information/user/integrationtest/UserRestApiIntegrationTest.java
@@ -1,0 +1,83 @@
+package com.information.user.integrationtest;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.spring.api.DBRider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DBRider
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class UserRestApiIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    @DataSet(value = "datasets/users.yml")
+    @Transactional
+    void 全てのユーザーが取得できること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/users"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        [
+                           {
+                             "id": 1,
+                             "name": "suzuki",
+                             "birthdate": "1973/07/22"
+                           },
+                           {
+                             "id": 2,
+                             "name": "kato",
+                             "birthdate": "1960/03/15"
+                           },
+                           {
+                             "id": 3,
+                             "name": "tanaka",
+                             "birthdate": "1991/12/08"
+                           }
+                        ]
+                        """
+                ));
+    }
+
+    @Test
+    @DataSet(value = "datasets/users.yml")
+    @Transactional
+    void 存在するユーザーのIDを指定したときにユーザーを取得できること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/users/1"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                           {
+                             "id": 1,
+                             "name": "suzuki",
+                             "birthdate": "1973/07/22"
+                           }
+                        """
+                ));
+    }
+
+    @Test
+    @DataSet(value = "datasets/users.yml")
+    @Transactional
+    void 存在しないユーザーのIDを指定したときにエラー内容を含めた例外を返すこと() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/users/0"))
+                .andExpect(status().isNotFound())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.timestamp").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.error").value(HttpStatus.NOT_FOUND.getReasonPhrase()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("user not found"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.path").value("/users/0"));
+    }
+}

--- a/src/test/java/com/information/user/mapper/UserMapperTest.java
+++ b/src/test/java/com/information/user/mapper/UserMapperTest.java
@@ -1,0 +1,54 @@
+package com.information.user.mapper;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.spring.api.DBRider;
+import com.information.user.User;
+import com.information.user.UserMapper;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DBRider
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class UserMapperTest {
+
+    @Autowired
+    UserMapper userMapper;
+
+    @Test
+    @DataSet(value = "datasets/users.yml")
+    @Transactional
+    void 全てのユーザーが取得できること() {
+        List<User> users = userMapper.getAll();
+        assertThat(users)
+                .hasSize(3)
+                .contains(
+                        new User(1, "suzuki", "1973/07/22"),
+                        new User(2, "kato", "1960/03/15"),
+                        new User(3, "tanaka", "1991/12/08")
+                );
+    }
+
+    @Test
+    @DataSet(value = "datasets/users.yml")
+    @Transactional
+    void 存在するユーザーのIDを指定したときにユーザーを取得できること() {
+        Optional<User> user = userMapper.findById(1);
+        assertThat(user).contains(new User(1, "suzuki", "1973/07/22"));
+    }
+
+    @Test
+    @Transactional
+    void 存在しないユーザーのIDを指定したときにOptionalEmptyが返されること() {
+        Optional<User> user = userMapper.findById(0);
+        assertThat(user).isEmpty();
+    }
+}

--- a/src/test/resources/datasets/users.yml
+++ b/src/test/resources/datasets/users.yml
@@ -1,0 +1,10 @@
+users:
+  - id: 1
+    name: "suzuki"
+    birthdate: "1973/07/22"
+  - id: 2
+    name: "kato"
+    birthdate: "1960/03/15"
+  - id: 3
+    name: "tanaka"
+    birthdate: "1991/12/08"

--- a/src/test/resources/dbunit.yml
+++ b/src/test/resources/dbunit.yml
@@ -1,0 +1,9 @@
+cacheConnection: false
+cacheTableNames: false
+properties:
+  schema: user_list
+caseInsensitiveStrategy: LOWERCASE
+connectionConfig:
+  url: "jdbc:mysql://localhost:3307/user_list"
+  user: "user"
+  password: "password"


### PR DESCRIPTION
# 目的
read 処理の DBUnit Test と Integration Test を実装します。

# 追加したテスト内容
### DBUnit Test について
- 全てのユーザーが取得できること
- 存在するユーザーのIDを指定したときにユーザーを取得できること
- 存在しないユーザーのIDを指定したときにOptionalEmptyが返されること

### Integration Test について
- 全てのユーザーが取得できること
- 存在するユーザーのIDを指定したときにユーザーを取得できること
- 存在しないユーザーのIDを指定したときにエラー内容を含めた例外を返すこと

# テスト実行結果
### DBUnit Test
![image](https://github.com/kino41/RaiseTech_last/assets/155221768/3769d908-10bc-481a-8745-56229620a87c)

### Integration Test
![image](https://github.com/kino41/RaiseTech_last/assets/155221768/8825353d-a9cc-4d2e-9956-fdf21e6ec934)

それぞれテストをパスしていることを確認しました。

---

予想以上にレビュー差分が多くなってしまいました、、次回気をつけます