### PR TITLE
post,delete処理のMapper単体テスト実装

### DIFF
--- a/src/test/java/com/information/user/mapper/UserMapperTest.java
+++ b/src/test/java/com/information/user/mapper/UserMapperTest.java
@@ -1,6 +1,7 @@
 package com.information.user.mapper;
 
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import com.information.user.User;
 import com.information.user.UserMapper;
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 
+import static com.information.user.User.createUser;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DBRider
@@ -50,5 +52,46 @@ class UserMapperTest {
     void 存在しないユーザーのIDを指定したときにOptionalEmptyが返されること() {
         Optional<User> user = userMapper.findById(0);
         assertThat(user).isEmpty();
+    }
+
+    @Test
+    @DataSet(value = "datasets/users.yml")
+    @ExpectedDataSet(value = "datasets/insertUsers.yml", ignoreCols = "id")
+    @Transactional
+    void 新規のユーザーの名前と生年月日を登録できること() {
+        User user = createUser("hayashi", "1992/03/09");
+        userMapper.insert(user);
+
+        Integer userId = user.getId();
+
+        Optional<User> insertedUser = userMapper.findById(userId);
+        assertThat(insertedUser).isPresent();
+        assertThat(insertedUser.get().getName()).isEqualTo("hayashi");
+        assertThat(insertedUser.get().getBirthdate()).isEqualTo("1992/03/09");
+    }
+
+    @Test
+    @DataSet(value = "datasets/users.yml")
+    @ExpectedDataSet(value = "datasets/deleteUsers.yml")
+    @Transactional
+    void 存在するユーザーのIDを指定したときにユーザーを削除できること() {
+        Optional<User> optionalUser = userMapper.findById(1);
+        assertThat(optionalUser).isPresent();
+
+        User user = optionalUser.get();
+        userMapper.deleteById(user.getId());
+
+        Optional<User> deleteOptionalUser = userMapper.findById(user.getId());
+        assertThat(deleteOptionalUser).isEmpty();
+    }
+
+    @Test
+    @Transactional
+    void 存在しないユーザーのIDを指定したときに削除が行われないこと() {
+        Optional<User> user = userMapper.findById(0);
+        assertThat(user).isEmpty();
+
+        int deletedRowCount = userMapper.deleteById(0);
+        assertThat(deletedRowCount).isZero();
     }
 }

--- a/src/test/java/com/information/user/mapper/UserMapperTest.java
+++ b/src/test/java/com/information/user/mapper/UserMapperTest.java
@@ -79,7 +79,8 @@ class UserMapperTest {
         assertThat(optionalUser).isPresent();
 
         User user = optionalUser.get();
-        userMapper.deleteById(user.getId());
+        int deletedRowCount = userMapper.deleteById(user.getId());
+        assertThat(deletedRowCount).isEqualTo(1);
 
         Optional<User> deleteOptionalUser = userMapper.findById(user.getId());
         assertThat(deleteOptionalUser).isEmpty();

--- a/src/test/resources/datasets/deleteUsers.yml
+++ b/src/test/resources/datasets/deleteUsers.yml
@@ -1,0 +1,7 @@
+users:
+  - id: 2
+    name: "kato"
+    birthdate: "1960/03/15"
+  - id: 3
+    name: "tanaka"
+    birthdate: "1991/12/08"

--- a/src/test/resources/datasets/insertUsers.yml
+++ b/src/test/resources/datasets/insertUsers.yml
@@ -1,0 +1,13 @@
+users:
+  - id: 1
+    name: "suzuki"
+    birthdate: "1973/07/22"
+  - id: 2
+    name: "kato"
+    birthdate: "1960/03/15"
+  - id: 3
+    name: "tanaka"
+    birthdate: "1991/12/08"
+  - id: 4
+    name: "hayashi"
+    birthdate: "1992/03/09"


### PR DESCRIPTION
# 目的
DBUnit を使用した Mapper 単体テストの実装を行います。

# テスト内容
- 新規のユーザーの名前と生年月日を登録できること
- 存在するユーザーのIDを指定したときにユーザーを削除できること
- 存在しないユーザーのIDを指定したときに削除が行われないこと

# テスト実行結果
![image](https://github.com/kino41/RaiseTech_last/assets/155221768/c21f4e39-7630-46fe-afd6-41b4876868ae)
計6個テストをパスしたことを確認