### PR TITLE
patch処理のMapper単体テスト実装

### DIFF
--- a/src/main/java/com/information/user/UserMapper.java
+++ b/src/main/java/com/information/user/UserMapper.java
@@ -20,7 +20,7 @@ public interface UserMapper {
     void insert(User user);
 
     @Update("UPDATE users SET name = #{name}, birthdate = #{birthdate} WHERE id = #{id}")
-    int update(User user);
+    void update(User user);
 
     @Select("SELECT * FROM users WHERE id = #{id}")
     Optional<User> findById(int id);

--- a/src/main/java/com/information/user/UserMapper.java
+++ b/src/main/java/com/information/user/UserMapper.java
@@ -20,7 +20,7 @@ public interface UserMapper {
     void insert(User user);
 
     @Update("UPDATE users SET name = #{name}, birthdate = #{birthdate} WHERE id = #{id}")
-    void update(User user);
+    int update(User user);
 
     @Select("SELECT * FROM users WHERE id = #{id}")
     Optional<User> findById(int id);

--- a/src/test/java/com/information/user/mapper/UserMapperTest.java
+++ b/src/test/java/com/information/user/mapper/UserMapperTest.java
@@ -101,6 +101,12 @@ class UserMapperTest {
 
         Optional<User> updateUser = userMapper.findById(0);
         assertThat(updateUser).isEmpty();
+
+        Optional<User> OptionalUser = userMapper.findById(1);
+        assertThat(OptionalUser).isPresent();
+        User existingUserDetails = OptionalUser.get();
+        assertThat(existingUserDetails.getName()).isNotEqualTo("sato");
+        assertThat(existingUserDetails.getBirthdate()).isNotEqualTo("1988/04/18");
     }
 
     @Test

--- a/src/test/java/com/information/user/mapper/UserMapperTest.java
+++ b/src/test/java/com/information/user/mapper/UserMapperTest.java
@@ -97,10 +97,7 @@ class UserMapperTest {
         Optional<User> user = userMapper.findById(0);
         assertThat(user).isEmpty();
 
-        User nonExistingUser = new User(0, "sato", "1988/04/18");
-        int updateCount = userMapper.update(nonExistingUser);
-
-        assertThat(updateCount).isZero();
+        userMapper.update(new User(0, "sato", "1988/04/18"));
 
         Optional<User> updateUser = userMapper.findById(0);
         assertThat(updateUser).isEmpty();

--- a/src/test/java/com/information/user/mapper/UserMapperTest.java
+++ b/src/test/java/com/information/user/mapper/UserMapperTest.java
@@ -72,6 +72,42 @@ class UserMapperTest {
 
     @Test
     @DataSet(value = "datasets/users.yml")
+    @ExpectedDataSet(value = "datasets/updateUsers.yml")
+    @Transactional
+    void 存在するユーザーのIDを指定したときにユーザーを更新できること() {
+        Optional<User> optionalUser = userMapper.findById(1);
+        assertThat(optionalUser).isPresent();
+        User existingUser = optionalUser.get();
+        assertThat(existingUser.getName()).isNotEqualTo("sato");
+        assertThat(existingUser.getBirthdate()).isNotEqualTo("1988/04/18");
+
+        User user = new User(1, "sato", "1988/04/18");
+        userMapper.update(user);
+
+        Optional<User> updateOptionalUser = userMapper.findById(1);
+        assertThat(updateOptionalUser).isPresent();
+        User updatedUser = updateOptionalUser.get();
+        assertThat(updatedUser.getName()).isEqualTo("sato");
+        assertThat(updatedUser.getBirthdate()).isEqualTo("1988/04/18");
+    }
+
+    @Test
+    @Transactional
+    void 存在しないユーザーのIDを指定したときに更新が行われないこと() {
+        Optional<User> user = userMapper.findById(0);
+        assertThat(user).isEmpty();
+
+        User nonExistingUser = new User(0, "sato", "1988/04/18");
+        int updateCount = userMapper.update(nonExistingUser);
+
+        assertThat(updateCount).isZero();
+
+        Optional<User> updateUser = userMapper.findById(0);
+        assertThat(updateUser).isEmpty();
+    }
+
+    @Test
+    @DataSet(value = "datasets/users.yml")
     @ExpectedDataSet(value = "datasets/deleteUsers.yml")
     @Transactional
     void 存在するユーザーのIDを指定したときにユーザーを削除できること() {

--- a/src/test/resources/datasets/updateUsers.yml
+++ b/src/test/resources/datasets/updateUsers.yml
@@ -1,0 +1,10 @@
+users:
+  - id: 1
+    name: "sato"
+    birthdate: "1988/04/18"
+  - id: 2
+    name: "kato"
+    birthdate: "1960/03/15"
+  - id: 3
+    name: "tanaka"
+    birthdate: "1991/12/08"


### PR DESCRIPTION
# 目的
DBUnit を使用した Mapper 単体テストの実装を行います。
今回は更新処理を実装します。

# テスト内容
- 存在するユーザーのIDを指定したときにユーザーを更新できること
- 存在しないユーザーのIDを指定したときに更新が行われないこと

# テスト実行結果
![image](https://github.com/kino41/RaiseTech_last/assets/155221768/15ea18d4-79a0-4d22-baff-9a913bd68750)
- テストを全てパスしていることを確認