### PR TITLE
post,delete機能のAPI動作テスト実装

### DIFF
--- a/src/test/java/com/information/user/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/com/information/user/integrationtest/UserRestApiIntegrationTest.java
@@ -109,6 +109,16 @@ class UserRestApiIntegrationTest {
 
     @Test
     @DataSet(value = "datasets/users.yml")
+    @Transactional
+    void 空のリクエストボディを送信した場合に400エラーを返すこと() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(""))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DataSet(value = "datasets/users.yml")
     @ExpectedDataSet(value = "datasets/deleteUsers.yml")
     @Transactional
     void ユーザーIDを指定して削除するAPIが正常に動作すること() throws Exception {


### PR DESCRIPTION
# 目的
API の登録機能・削除機能が正常に動作するかを検証するテストを実装します。

# 実装内容
- 新しいユーザーを作成しそのユーザーに固有のIDを割り当てて登録できること
- ユーザーIDを指定して削除するAPIが正常に動作すること
- 存在しないユーザーIDを指定して削除したときに404エラーを返すこと

# テスト実行結果
![image](https://github.com/kino41/RaiseTech_last/assets/155221768/6bf3eba9-df79-41f6-9eeb-d6a14af6e760)
全てのテストが正常に通ることを確認